### PR TITLE
在庫カレンダー機能追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -173,7 +173,7 @@ public class RentalManageController{
  
         }
    
-            return "rental/edit";
+        return "rental/edit";
     }
     /**
     * Postのリクエストがあった場合にこの処理を行う
@@ -273,7 +273,7 @@ public class RentalManageController{
             return "redirect:/rental/index";
 
         } catch (Exception e) {
-            // エラーが発生した場合の処理a
+            // エラーが発生した場合の処理
             log.error("更新処理中にエラーが発生しました: " + e.getMessage());
             model.addAttribute("errorMessage", "更新処理中にエラーが発生しました");
  

--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -2,8 +2,11 @@
 package jp.co.metateam.library.controller;
  
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
- 
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -17,6 +20,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
  
 import jakarta.validation.Valid;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.CalendarDto;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.service.BookMstService;
@@ -144,16 +148,14 @@ public class StockController {
         Integer daysInMonth = startDate.lengthOfMonth();
  
         List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<String> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        List<CalendarDto> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
  
         model.addAttribute("targetYear", targetYear);
         model.addAttribute("targetMonth", targetMonth);
         model.addAttribute("daysOfWeek", daysOfWeek);
         model.addAttribute("daysInMonth", daysInMonth);
- 
         model.addAttribute("stocks", stocks);
- 
+
         return "stock/calendar";
     }
 }
- 

--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -2,10 +2,7 @@
 package jp.co.metateam.library.controller;
  
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;

--- a/src/main/java/jp/co/metateam/library/model/CalendarDto.java
+++ b/src/main/java/jp/co/metateam/library/model/CalendarDto.java
@@ -1,0 +1,19 @@
+package jp.co.metateam.library.model;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+
+public class CalendarDto {
+
+    private String title;
+
+    private int totalCount;
+
+    private List<DailyDuplication> countAvailableRental;
+    
+}

--- a/src/main/java/jp/co/metateam/library/model/DailyDuplication.java
+++ b/src/main/java/jp/co/metateam/library/model/DailyDuplication.java
@@ -1,0 +1,20 @@
+package jp.co.metateam.library.model;
+
+import java.util.List;
+import java.util.Date;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+
+public class DailyDuplication {
+
+    private String stockId;
+
+    private Date expectedRentalOn;
+
+    private Integer dailyCount;
+    
+}

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -2,8 +2,10 @@ package jp.co.metateam.library.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Date;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.Stock;
@@ -20,4 +22,15 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
 	Optional<Stock> findById(String id);
     
     List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
+    //書籍IDと在庫ステータス
+
+    //日付けごとの在庫数
+    @Query(value = "SELECT s.id " +
+            "FROM stocks s " +
+            "LEFT JOIN rental_manage rm ON s.id = rm.stock_id " +
+            "JOIN book_mst bm ON s.book_id = bm.id " +
+            "WHERE bm.id = ?1 AND s.status = '0' AND (rm.status IS NULL OR rm.expected_rental_on > ?2 OR ?2 > rm.expected_return_on) "
+            +
+            "GROUP BY s.id", nativeQuery = true)
+    List<Object[]> calender(Long bookId, Date dayOfMonth);
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -24,7 +24,7 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
     List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
     //書籍IDと在庫ステータス
 
-    //日付けごとの在庫数
+    //SQLで取得
     @Query(value = "SELECT s.id " +
             "FROM stocks s " +
             "LEFT JOIN rental_manage rm ON s.id = rm.stock_id " +

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -1,13 +1,10 @@
 package jp.co.metateam.library.service;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Random;
 import java.util.Date;
 import java.util.Calendar;
 
@@ -16,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jp.co.metateam.library.constants.Constants;
-import jp.co.metateam.library.controller.StockController;
 import jp.co.metateam.library.model.BookMst;
 import jp.co.metateam.library.model.CalendarDto;
 import jp.co.metateam.library.model.DailyDuplication;
@@ -25,9 +21,6 @@ import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
 import jp.co.metateam.library.repository.RentalManageRepository;
 import jp.co.metateam.library.repository.StockRepository;
-
-//import java.util.Map;
-
 @Service
 public class StockService {
     private final BookMstRepository bookMstRepository;
@@ -179,5 +172,4 @@ public class StockService {
         }
         return values;
     }
-}
-    
+}    

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -1,32 +1,47 @@
 package jp.co.metateam.library.service;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
+import java.util.Date;
+import java.util.Calendar;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jp.co.metateam.library.constants.Constants;
+import jp.co.metateam.library.controller.StockController;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.CalendarDto;
+import jp.co.metateam.library.model.DailyDuplication;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
+import jp.co.metateam.library.repository.RentalManageRepository;
 import jp.co.metateam.library.repository.StockRepository;
+
+//import java.util.Map;
 
 @Service
 public class StockService {
     private final BookMstRepository bookMstRepository;
     private final StockRepository stockRepository;
+    private final RentalManageRepository rentalManageRepository;
+    
+
+
 
     @Autowired
-    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository){
+    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository, RentalManageRepository rentalManageRepository){ 
         this.bookMstRepository = bookMstRepository;
         this.stockRepository = stockRepository;
+        this.rentalManageRepository = rentalManageRepository;
     }
 
     @Transactional
@@ -104,20 +119,65 @@ public class StockService {
 
         return daysOfWeek;
     }
+    
+    public List<CalendarDto> generateValues(Integer year, Integer month, Integer daysInMonth) {
+    //指定された年・月に対応するカレンダーの情報(CalendarDtoのリスト)を生成
 
-    public List<String> generateValues(Integer year, Integer month, Integer daysInMonth) {
-        // FIXME ここで各書籍毎の日々の在庫を生成する処理を実装する
-        // FIXME ランダムに値を返却するサンプルを実装している
-        String[] stockNum = {"1", "2", "3", "4", "×"};
-        Random rnd = new Random();
-        List<String> values = new ArrayList<>();
-        values.add("スッキリわかるJava入門 第4版"); // 対象の書籍名
-        values.add("10"); // 対象書籍の在庫総数
-        
-        for (int i = 1; i <= daysInMonth; i++) {
-            int index = rnd.nextInt(stockNum.length);
-            values.add(stockNum[index]);
+        List<CalendarDto> values = new ArrayList<>();
+        List<BookMst> countByLendableBooks = this.bookMstRepository.findAll();
+        //findAll()で全ての書籍情報を取得し、countByLendableBooksリストに格納
+
+        for (int i = 0; i < countByLendableBooks.size(); i++) {
+        //書籍Id分の繰り返しの処理(書籍名と利用可能在庫数の表示)
+
+            BookMst book = countByLendableBooks.get(i);
+            //iに対応する要素を取得し、BookMst型の変数bookに格納
+            List<Stock> stockCount = this.stockRepository.findByBookMstIdAndStatus(book.getId(), Constants.STOCK_AVAILABLE);
+            //指定された書籍IDと在庫状態(=Constants.STOCK_AVAILABLE)に基づいて在庫情報を取得し、stockCountリストに格納
+
+            CalendarDto calendarDto = new CalendarDto();
+            calendarDto.setTitle(book.getTitle());
+            //書籍のタイトルをCalendarDtoオブジェクトのtitleフィールドに設定(書籍名)
+            calendarDto.setTotalCount(stockCount.size());
+            //stockCountリストの要素数を取得し、それをCalendarDtoオブジェクトのtotalCountフィールドに設定(利用可能在庫数)
+
+            List<DailyDuplication> dailyDuplication = new ArrayList<>();
+
+            for (int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
+            //日にち分の繰り返しの処理(日付けごとの在庫数)
+
+                Calendar cl = Calendar.getInstance();
+                //現在の日付・時刻に対応するCalendarオブジェクトを取得
+                cl.set(Calendar.YEAR, year);
+                //年を指定されたyearに設定
+                cl.set(Calendar.MONTH, month - 1);
+                //月を指定されたmonthに設定
+                cl.set(Calendar.DATE, dayOfMonth);
+                //日を指定されたdayOfMonthに設定
+                Date date = new Date();
+                date = cl.getTime();
+                //設定された年月日に対応する日付を取得し、dateに設定
+
+                DailyDuplication dailyList = new DailyDuplication();
+                List<Object[]> stockList = stockRepository.calender(book.getId(),date);
+                //指定された書籍IDと日付に対応する在庫情報を取得し、結果をstockListというリストに格納
+
+                dailyList.setExpectedRentalOn(date);
+                //貸出予定日の設定
+                dailyList.setStockId(stockList.isEmpty() ? null : stockList.get(0)[0].toString());
+                //在庫管理番号を設定
+                dailyList.setDailyCount(stockList.size());
+                //日ごとの貸出可能な在庫数(=stockListの要素数)を設定
+
+                dailyDuplication.add(dailyList);
+            }
+
+            calendarDto.setCountAvailableRental(dailyDuplication);
+            //CalendarDtoオブジェクトのcountAvailableRentalフィールドにdailyDuplicationリストを設定
+
+            values.add(calendarDto);
         }
         return values;
     }
 }
+    

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -36,9 +36,23 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
+                            <tr th:each="title, titleIndex: ${titles}">
                                 <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
-                                <td th:each="stock, stat : ${stocks}" th:text="${stock}"></td>
+                                <tr th:each="book: ${stocks}">
+                                    <td th:text="${book.title}"></td> <!-- 一つ目の値 -->
+                                    <td th:text="${book.totalCount}"></td> <!-- 二つ目の値 -->
+                                    <th:block th:each="stock, stat :${book.countAvailableRental}">
+                                        <th:block th:if="${stock.dailyCount == 0}">
+                                        <td>×</td>
+                                        </th:block>   
+                                        <th:block th:if="${stock.dailyCount >= 1}">
+                                            <td> <a th:text="${stock.dailyCount}"
+                                                    th:href="@{/rental/add(stockId=${stock.stockId}, expectedRentalOn=${#dates.format(stock.expectedRentalOn, 'yyyy-MM-dd')})}"
+                                                    class="link"></a>
+                                            </td>
+                                        </th:block>  
+                                    </th:block> 
+                                </td>         
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
在庫カレンダー機能を追加しました。
・書籍の利用可能在庫数と日ごとの貸出可能な在庫数を表示
・日ごとの貸出可能な在庫数にリンクを張り、押下すると貸出登録画面に遷移
・貸出登録画面遷移後に、貸出予定日と在庫管理番号を表示